### PR TITLE
Include sphinx_reload.py in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ metadata = dict({
         "livereload >= 2.5.1",
     ],
     "packages": find_packages(),
+    "py_modules": ["sphinx_reload"],
     "entry_points": {
         "console_scripts": [
             "sphinx-reload = sphinx_reload:main"


### PR DESCRIPTION
`sphinx_reload.py` is not included in the built archives when calling `python setup.py build`.
This commit fixes that. Will also close #1 