### PR TITLE
Use RecursiveGlobWatcher instance instead of class

### DIFF
--- a/sphinx_reload.py
+++ b/sphinx_reload.py
@@ -75,7 +75,7 @@ class SphinxReload(object):
         self._spy_on.extend(glob_names)
 
     def _run(self, build_func, root, port):
-        watcher = _RecursiveGlobWatcher if sys.version_info >= (3, 5) else None
+        watcher = _RecursiveGlobWatcher() if sys.version_info >= (3, 5) else None
         server = livereload.Server(watcher=watcher)
         for pattern in self._spy_on:
             server.watch(pattern, build_func)


### PR DESCRIPTION
Fixes #3.

For Python versions >= 3.5, we use a custom watcher that can search for a file pattern recursively using the `recursive` parameter of `glob.glob`. However, we are currently passing the class directly to the server instead of using an instance, which is what the server expects. 