### PR TITLE
Honor positional arguments when users assert `--watch` options.

### DIFF
--- a/sphinx_reload.py
+++ b/sphinx_reload.py
@@ -116,11 +116,6 @@ def _create_parser():
         version='v%s' % __version__
     )
     parser.add_argument(
-        "documentation_root",
-        help="Your documentation's root directory (i.e., the place where "
-             "`sphinx-build` put the Makefile)."
-    )
-    parser.add_argument(
         "--host",
         help="The host to serve files",
         default="localhost"
@@ -144,6 +139,11 @@ def _create_parser():
         default=5500,
         type=int,
         help="The port number from which to serve your documentation."
+    )
+    parser.add_argument(
+        "documentation_root",
+        help="Your documentation's root directory (i.e., the place where "
+             "`sphinx-build` put the Makefile)."
     )
     return parser
 

--- a/sphinx_reload.py
+++ b/sphinx_reload.py
@@ -129,7 +129,7 @@ def _create_parser():
         "--watch",
         metavar="PATTERN",
         default=[],
-        nargs="+",
+        action="append",
         help="File patterns to watch for changes, on which documentation "
              "should be rebuilt and served again."
     )

--- a/sphinx_reload.py
+++ b/sphinx_reload.py
@@ -152,7 +152,6 @@ def main():
     parser = _create_parser()
     namespace = parser.parse_args()
     reload = SphinxReload()
-    reload.watch(*namespace.watch)
 
     if namespace.watch:
         reload.watch(*namespace.watch)


### PR DESCRIPTION
When users specify globs to watch as their final *option* on the command line, argparse will consume all following words as elements of the watch list. eg.
```bash
sphinx_reload --watch 'dir1/*' 'dir2/*' path/to/doc_root
```
results in all of: `dir1/*`, `dir2/*`, and `path/to/doc_root` being added to the `namespace.watch` list, and nothing being parsed as the `documentation_root` positional argument. So argparse throws an error and `sphinx_reload` returns code 2.

This PR changes the argument parser to require that users specify `--watch` prior to *each* glob. But this means that we can correctly accept positional arguments. eg.

```bash
sphinx_reload --watch 'dir1/*' --watch 'dir2/*' path/to/doc_root
```

This PR also fixes a bug where globs are added to the watch list twice, resulting in a continuous loop of watch updates.

# Testing
Manually tested these changes using a blank sphinx project created with `sphinx-quickstart`.

# Maintainer
This PR implies a change to a user API (the command line syntax).