### PR TITLE
Fixed import of unavailable sphinx_reload during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ with open(os.path.join(os.path.dirname(__file__), "sphinx_reload.py"), "r") as f
         if "__version__ = " in line:
             __version__ = eval(line.split("=")[1].strip())
             break
+    else:
+        raise RuntimeError("No `__version__` found in `sphinx_reload.py`.")
 
 
 def read(filename):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
 # Standard library imports
 from setuptools import setup, find_packages
+import os
 
 # Local imports
-import sphinx_reload
+with open(os.path.join(os.path.dirname(__file__), "sphinx_reload.py"), "r") as f:
+    for line in f:
+        if "__version__ = " in line:
+            __version__ = eval(line.split("=")[1].strip())
+            break
 
 
 def read(filename):
@@ -14,7 +19,7 @@ metadata = dict({
     "name": "sphinx-reload",
     "author": "P. Raj Kumar",
     "author_email": "raj.pritvi.kumar@gmail.com",
-    "version": sphinx_reload.__version__,
+    "version": __version__,
     "url": "https://github.com/prkumar/sphinx-reload",
     "license": "MIT",
     "description": "Live preview your Sphinx documentation",


### PR DESCRIPTION
The `import sphinx_reload` in setup.py causes several problems:
1) Each install requirement of `sphinx_reload` becomes a build requirement as well; when I do `pip install -e .` for example, I'm hit with a `ModuleNotFoundError` on the third-party import statements in `sphinx_reload.py`: `import livereload`
2) The `sphinx_reload` module isn't necesarily available on the path, or it might discover another installed `sphinx_reload`, messing with the `__version__` detection.

This PR adresses these issues by instead scanning the module line by line for a `__version__` declaration, and evaluates the right hand side of the assignment statement, without importing it (1) and always finding the same file relative to `setup.py` (2)